### PR TITLE
feat: Make Campaign Details section collapsible

### DIFF
--- a/campaign_crafter_ui/src/pages/CampaignEditorPage.css
+++ b/campaign_crafter_ui/src/pages/CampaignEditorPage.css
@@ -20,7 +20,8 @@
   margin-bottom: 2rem; /* Increased bottom margin for better separation */
 }
 
-/* Style for clickable h3 headers in collapsible sections */
+/* Style for clickable h2/h3 headers in collapsible sections */
+.editor-section > h2[style*="cursor: pointer"],
 .editor-section > h3[style*="cursor: pointer"] {
   margin-bottom: 1rem; /* Space below header before content */
   padding: 0.75rem 1rem; /* Padding inside the header */
@@ -29,7 +30,11 @@
   border-radius: 6px; /* Rounded corners for the header bar */
   transition: background-color 0.2s ease-in-out;
   border-bottom: 1px solid var(--border-color);
+  /* Ensure cursor property is explicitly set if not already via inline style, though inline style takes precedence */
+  cursor: pointer;
 }
+
+.editor-section > h2[style*="cursor: pointer"]:hover,
 .editor-section > h3[style*="cursor: pointer"]:hover {
   background-color: var(--primary-color); /* Slightly darker on hover */
   color: white;

--- a/campaign_crafter_ui/src/pages/CampaignEditorPage.tsx
+++ b/campaign_crafter_ui/src/pages/CampaignEditorPage.tsx
@@ -61,6 +61,7 @@ const CampaignEditorPage: React.FC = () => {
   // State for UI collapsible sections
   const [isLLMSettingsCollapsed, setIsLLMSettingsCollapsed] = useState<boolean>(false);
   const [isAddSectionCollapsed, setIsAddSectionCollapsed] = useState<boolean>(true);
+  const [isCampaignDetailsCollapsed, setIsCampaignDetailsCollapsed] = useState<boolean>(true); // Default to true
 
   const processedToc = useMemo(() => {
     if (!campaign?.toc || !sections?.length) {
@@ -315,22 +316,44 @@ const CampaignEditorPage: React.FC = () => {
 
   return (
     <div className="campaign-editor-page">
-      <header className="campaign-header editor-section">
-        <label htmlFor="campaignTitle" className="form-label">Campaign Title:</label>
-        <input type="text" id="campaignTitle" className="form-input form-input-title" value={editableTitle} onChange={(e) => setEditableTitle(e.target.value)} />
-      </header>
+      <div className="campaign-main-details-section editor-section">
+        <h2 onClick={() => setIsCampaignDetailsCollapsed(!isCampaignDetailsCollapsed)} style={{ cursor: 'pointer' }}>
+          {isCampaignDetailsCollapsed ? '▶' : '▼'} Campaign Details & Overview
+        </h2>
+        {!isCampaignDetailsCollapsed && (
+          <>
+            <header className="campaign-header editor-section">
+              <label htmlFor="campaignTitle" className="form-label">Campaign Title:</label>
+              <input type="text" id="campaignTitle" className="form-input form-input-title" value={editableTitle} onChange={(e) => setEditableTitle(e.target.value)} />
+            </header>
 
-      <section className="campaign-detail-section editor-section">
-        <label htmlFor="campaignInitialPrompt" className="form-label">Initial User Prompt:</label>
-        <textarea id="campaignInitialPrompt" className="form-textarea" value={editableInitialPrompt} onChange={(e) => setEditableInitialPrompt(e.target.value)} rows={5} />
-      </section>
-      
-      <div className="save-actions editor-section">
-        <button onClick={handleSaveChanges} disabled={isSaving || !hasChanges} className="save-button main-save-button">
-          {isSaving ? 'Saving Details...' : 'Save Campaign Details'}
-        </button>
-        {saveError && <p className="error-message save-feedback">{saveError}</p>}
-        {saveSuccess && <p className="success-message save-feedback">{saveSuccess}</p>}
+            <section className="campaign-detail-section editor-section">
+              <label htmlFor="campaignInitialPrompt" className="form-label">Initial User Prompt:</label>
+              <textarea id="campaignInitialPrompt" className="form-textarea" value={editableInitialPrompt} onChange={(e) => setEditableInitialPrompt(e.target.value)} rows={5} />
+            </section>
+
+            <div className="save-actions editor-section">
+              <button onClick={handleSaveChanges} disabled={isSaving || !hasChanges} className="save-button main-save-button">
+                {isSaving ? 'Saving Details...' : 'Save Campaign Details'}
+              </button>
+              {saveError && <p className="error-message save-feedback">{saveError}</p>}
+              {saveSuccess && <p className="success-message save-feedback">{saveSuccess}</p>}
+            </div>
+
+            {campaign.concept && (
+              <section className="campaign-detail-section read-only-section">
+                <h2>Campaign Concept (Read-Only)</h2>
+                <div className="concept-content"><ReactMarkdown>{campaign.concept}</ReactMarkdown></div>
+              </section>
+            )}
+            {campaign.toc && (
+              <section className="campaign-detail-section read-only-section">
+                <h2>Table of Contents (Read-Only)</h2>
+                <div className="toc-content"><ReactMarkdown>{processedToc}</ReactMarkdown></div>
+              </section>
+            )}
+          </>
+        )}
       </div>
 
       <div className="llm-settings-and-actions editor-section">
@@ -394,19 +417,6 @@ const CampaignEditorPage: React.FC = () => {
             {suggestedTitles.map((title, index) => (<li key={index} className="title-item">{title}</li>))}
           </ul>
           <button onClick={() => setSuggestedTitles(null)} className="dismiss-titles-button">Dismiss</button>
-        </section>
-      )}
-
-      {campaign.concept && (
-        <section className="campaign-detail-section read-only-section">
-          <h2>Campaign Concept (Read-Only)</h2>
-          <div className="concept-content"><ReactMarkdown>{campaign.concept}</ReactMarkdown></div>
-        </section>
-      )}
-      {campaign.toc && (
-        <section className="campaign-detail-section read-only-section">
-          <h2>Table of Contents (Read-Only)</h2>
-          <div className="toc-content"><ReactMarkdown>{processedToc}</ReactMarkdown></div>
         </section>
       )}
 


### PR DESCRIPTION
The main campaign details and overview section in the Campaign Editor is now collapsible to improve UI space management, especially when this section is large.

Key changes:
- Wrapped Campaign Title, Initial User Prompt, Save Details button, Campaign Concept, and Table of Contents into a new unified collapsible section titled 'Campaign Details & Overview'.
- This new section is collapsed by default.
- Clicking the header toggles its visibility.
- Styling for the new collapsible `h2` header is consistent with existing collapsible `h3` headers.

This addresses the issue where the initial part of the campaign editor could take up too much vertical space.