### PR TITLE
I've fixed a NameError in `random_table_service.py` by importing `Pat…

### DIFF
--- a/campaign_crafter_api/app/models.py
+++ b/campaign_crafter_api/app/models.py
@@ -14,7 +14,7 @@ class LLMConfig(LLMConfigBase):
     owner_id: int # foreign key to User, will be added later
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class CampaignTitlesResponse(BaseModel):
     titles: List[str]
@@ -61,7 +61,7 @@ class CampaignSection(CampaignSectionBase):
     campaign_id: int # foreign key to Campaign
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class CampaignSectionListResponse(BaseModel):
     sections: List[CampaignSection] # Reuses the existing CampaignSection model
@@ -90,7 +90,7 @@ class Campaign(CampaignBase):
     sections: List['CampaignSection'] = [] # Assuming CampaignSection is defined elsewhere or properly forward referenced
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 # Note: The duplicate CampaignSectionBase and CampaignSection definitions were removed.
 # The first definitions encountered in the file are kept:
@@ -143,7 +143,7 @@ class User(UserBase): # For responses
     llm_configs: List[LLMConfig] = []
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 # Feature Models
 class FeatureBase(BaseModel):
@@ -161,7 +161,7 @@ class Feature(FeatureBase):
     id: int
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 # RollTableItem Models
 class RollTableItemBase(BaseModel):
@@ -182,7 +182,7 @@ class RollTableItem(RollTableItemBase):
     roll_table_id: int
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 # RollTable Models
 class RollTableBase(BaseModel):
@@ -202,7 +202,7 @@ class RollTable(RollTableBase):
     items: List[RollTableItem] = []
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class LLMTextGenerationResponse(BaseModel):
     text: str  # Placeholder field; add more fields as needed

--- a/campaign_crafter_api/app/services/random_table_service.py
+++ b/campaign_crafter_api/app/services/random_table_service.py
@@ -1,5 +1,7 @@
+import csv # Added csv import
 import random
 from typing import List, Optional
+from pathlib import Path
 from sqlalchemy.orm import Session
 from app import crud, models, orm_models # Assuming models might be needed for Pydantic types if returned
 

--- a/campaign_crafter_api/app/tests/test_services.py
+++ b/campaign_crafter_api/app/tests/test_services.py
@@ -1,0 +1,37 @@
+import unittest
+from app.services.random_table_service import RandomTableService
+from app import models
+import pydantic
+
+class TestServices(unittest.TestCase):
+    def test_random_table_service_instantiation(self):
+        """Tests if RandomTableService can be instantiated."""
+        try:
+            service = RandomTableService()
+            self.assertIsInstance(service, RandomTableService)
+        except Exception as e:
+            self.fail(f"RandomTableService instantiation failed: {e}")
+
+    def test_pydantic_model_config_from_attributes(self):
+        """
+        Tests if Pydantic models in app.models have from_attributes = True in their Config.
+        """
+        for name, obj in vars(models).items():
+            # Check if obj is a class and a subclass of pydantic.BaseModel
+            if isinstance(obj, type) and issubclass(obj, pydantic.BaseModel) and obj != pydantic.BaseModel:
+                # Check if the model has a Config class
+                if hasattr(obj, 'Config'):
+                    config = obj.Config
+                    # Check for from_attributes = True
+                    self.assertTrue(
+                        getattr(config, 'from_attributes', False),
+                        f"Model {name} does not have from_attributes = True in its Config."
+                    )
+                else:
+                    # This case could be a fail or a pass depending on requirements.
+                    # If all models are expected to have a Config with from_attributes,
+                    # then this should be a self.fail().
+                    # For now, we'll assume models without Config are fine or handled elsewhere.
+                    print(f"Model {name} does not have a Config class. Skipping from_attributes check.")
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…h` from `pathlib` and `csv`. I also replaced `orm_mode = True` with `from_attributes = True` in Pydantic model configurations in `models.py` to address a UserWarning. Finally, I added tests for `RandomTableService` instantiation and to verify Pydantic model configurations.