### PR TITLE
Fix: Include selectedLLMId in TOC generation payload

### DIFF
--- a/campaign_crafter_ui/src/pages/CampaignEditorPage.tsx
+++ b/campaign_crafter_ui/src/pages/CampaignEditorPage.tsx
@@ -363,7 +363,8 @@ const CampaignEditorPage: React.FC = () => {
     setTocError(null);
     setSaveSuccess(null);
     try {
-      const updatedCampaign = await campaignService.generateCampaignTOC(campaignId, {});
+      const payload = { model_id_with_prefix: selectedLLMId };
+      const updatedCampaign = await campaignService.generateCampaignTOC(campaignId, payload);
       setCampaign(updatedCampaign);
       setSaveSuccess("Table of Contents generated successfully!");
       setTimeout(() => setSaveSuccess(null), 3000);


### PR DESCRIPTION
The frontend was sending an empty payload when requesting TOC generation. This caused an error in the backend because it expects a 'model_id_with_prefix' field.

This commit updates the `CampaignEditorPage.tsx` to include the `selectedLLMId` as `model_id_with_prefix` in the payload sent to the backend.