### PR TITLE
feat: Replace default logo with "CC" version

### DIFF
--- a/campaign_crafter_ui/src/components/common/Layout.tsx
+++ b/campaign_crafter_ui/src/components/common/Layout.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
+import { ReactComponent as Logo } from '../../../logo_cc.svg';
 import './Layout.css';
 // Assuming logo_placeholder.svg is in the public folder,
 // it can be referenced directly by path in Vite/CRA.
@@ -17,7 +18,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     <div className="app-layout">
       <header className="app-header">
         <Link to="/" className="app-title-link">
-          <img src="/logo_placeholder.svg" alt="Campaign Crafter Logo" className="app-logo" />
+          <Logo className="app-logo" title="Campaign Crafter Logo" />
           <h1>Campaign Crafter</h1>
         </Link>
         <nav className="app-nav">

--- a/campaign_crafter_ui/src/logo_cc.svg
+++ b/campaign_crafter_ui/src/logo_cc.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="50px" fill="black">CC</text>
+</svg>


### PR DESCRIPTION
Replaced the placeholder logo in the header with a new SVG logo displaying "CC".

- Created `campaign_crafter_ui/src/logo_cc.svg`.
- Modified `campaign_crafter_ui/src/components/common/Layout.tsx` to import and render the new SVG logo.