### PR TITLE
Fix: Correct JSX syntax error in CampaignEditorPage

### DIFF
--- a/campaign_crafter_ui/package-lock.json
+++ b/campaign_crafter_ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
+        "@microsoft/fetch-event-source": "^2.0.1",
         "@mui/icons-material": "^5.15.0",
         "@mui/material": "^5.15.0",
         "@testing-library/dom": "^10.4.0",
@@ -2929,6 +2930,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.17.1",

--- a/campaign_crafter_ui/src/pages/CampaignEditorPage.tsx
+++ b/campaign_crafter_ui/src/pages/CampaignEditorPage.tsx
@@ -1009,23 +1009,24 @@ const CampaignEditorPage: React.FC = () => {
                     </div>
                   </>
                 ) : (
-                  <DetailedProgressDisplay
-                    percent={detailedProgressPercent}
-                    currentTitle={detailedProgressCurrentTitle}
-                    error={seedSectionsError} // Pass the error to the component
-                    title="Seeding Sections from Table of Contents..." // Optional: override default title
-                  />
-                  <Button
-                    onClick={handleCancelSeeding}
-                    className="action-button secondary-action-button" // Using secondary style for cancel
-                    style={{ marginTop: '10px' }}
-                    icon={<CancelIcon />}
-                    tooltip="Stop the section seeding process"
-                    disabled={!isSeedingSections} // Disable if not actively seeding (e.g., already completed/errored out but progress still visible briefly)
-                  >
-                    Cancel Seeding
-                  </Button>
-                </>
+                  <>
+                    <DetailedProgressDisplay
+                      percent={detailedProgressPercent}
+                      currentTitle={detailedProgressCurrentTitle}
+                      error={seedSectionsError} // Pass the error to the component
+                      title="Seeding Sections from Table of Contents..." // Optional: override default title
+                    />
+                    <Button
+                      onClick={handleCancelSeeding}
+                      className="action-button secondary-action-button" // Using secondary style for cancel
+                      style={{ marginTop: '10px' }}
+                      icon={<CancelIcon />}
+                      tooltip="Stop the section seeding process"
+                      disabled={!isSeedingSections} // Disable if not actively seeding (e.g., already completed/errored out but progress still visible briefly)
+                    >
+                      Cancel Seeding
+                    </Button>
+                  </>
                 )}
               </div>
             )}


### PR DESCRIPTION
Adjacent JSX elements (<DetailedProgressDisplay /> and <Button />) in `campaign_crafter_ui/src/pages/CampaignEditorPage.tsx` were not wrapped in an enclosing tag, causing a syntax error.

This commit wraps these elements in a JSX fragment (<>...</>) to resolve the error. This also resolved subsequent TypeScript compilation errors.