### PR TITLE
refactor: Remove temporary debug logging from auth_service

### DIFF
--- a/campaign_crafter_api/app/services/auth_service.py
+++ b/campaign_crafter_api/app/services/auth_service.py
@@ -14,8 +14,6 @@ async def get_current_user(
     token: Annotated[str, Depends(oauth2_scheme)],
     db: Annotated[Session, Depends(get_db)]
 ) -> models.User: # Return Pydantic model
-    print(f"[AUTH_DEBUG] get_current_user called. Received token: {token[:30]}...")
-
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
@@ -23,35 +21,20 @@ async def get_current_user(
     )
     try:
         payload = decode_access_token(token)
-        print(f"[AUTH_DEBUG] Decoded payload: {payload}")
-
         if payload is None:
-            print("[AUTH_DEBUG] Payload is None after decoding.")
             raise credentials_exception
 
         username: Optional[str] = payload.get("sub")
         if username is None:
-            print("[AUTH_DEBUG] Username (sub) not in payload.")
             raise credentials_exception
 
-        print(f"[AUTH_DEBUG] Username from token: {username}")
-
-        # Create TokenData Pydantic model instance - already present in original code, good for validation.
-        # token_data = models.TokenData(username=username)
-        # No, token_data was used for crud.get_user_by_username(db, username=token_data.username),
-        # we can directly use 'username' string.
-
-    except JWTError as e:
-        print(f"[AUTH_DEBUG] JWTError during token decoding: {str(e)}")
+    except JWTError:
         raise credentials_exception
 
     db_user_orm = crud.get_user_by_username(db, username=username)
 
     if db_user_orm is None:
-        print(f"[AUTH_DEBUG] User '{username}' not found in database.")
         raise credentials_exception
-
-    print(f"[AUTH_DEBUG] User '{username}' found in database. Disabled status: {db_user_orm.disabled}")
 
     user_pydantic = models.User.from_orm(db_user_orm)
     return user_pydantic


### PR DESCRIPTION
Removed temporary print statements from the get_current_user function in campaign_crafter_api/app/services/auth_service.py. These logs were added for diagnosing token validation issues and are no longer needed now that the authentication system is confirmed to be working.