### PR TITLE
Fix: Update Gemini default model to be compatible with v1beta API

### DIFF
--- a/campaign_crafter_api/app/services/gemini_service.py
+++ b/campaign_crafter_api/app/services/gemini_service.py
@@ -10,7 +10,7 @@ import asyncio # For testing async methods in __main__
 
 class GeminiLLMService(AbstractLLMService):
     PROVIDER_NAME = "gemini" # Class variable for provider name
-    DEFAULT_MODEL = "gemini-pro" 
+    DEFAULT_MODEL = "gemini-1.5-flash"
 
     def __init__(self):
         self.api_key = settings.GEMINI_API_KEY


### PR DESCRIPTION
The Gemini service was failing due to an incompatibility between the `gemini-pro` model and the `v1beta` API version. The error message "404 models/gemini-pro is not found for API version v1beta" indicated this.

This change updates the `DEFAULT_MODEL` in
`campaign_crafter_api/app/services/gemini_service.py` from `"gemini-pro"` to `"gemini-1.5-flash"`.

The `gemini-1.5-flash` model is confirmed to be compatible with the `v1beta` API version, as it's already in use in the Swift client code (`TextEditorApp/TextEditorApp/GeminiClient.swift`) which also targets the `v1beta` API endpoint. This change aligns the Python backend's default model with a known working configuration.