### PR TITLE
feat: Mood board enhancements and bug fixes

### DIFF
--- a/campaign_crafter_ui/src/components/common/MoodBoardPanel.css
+++ b/campaign_crafter_ui/src/components/common/MoodBoardPanel.css
@@ -1,22 +1,34 @@
 /* src/components/common/MoodBoardPanel.css */
 
-.mood-board-panel { /* Renamed from .thematic-image-display-wrapper */
-  position: fixed;
-  /* Positioning will be handled by parent in CampaignEditorPage.tsx for .thematic-image-side-panel */
-  /* bottom: 20px;
-  right: 20px; */
-  width: 100%; /* Take full width of its container (.thematic-image-side-panel) */
-  height: 100%; /* Take full height of its container */
+.mood-board-panel {
+  position: relative; /* Changed from fixed */
+  width: 100%;
+  height: 100%;
   background-color: var(--surface-color, #fff);
-  /* border: 1px solid var(--border-color, #dee2e6); */ /* Border handled by parent panel */
-  /* border-radius: var(--border-radius-lg, 0.5rem); */ /* Radius handled by parent panel */
-  /* box-shadow: var(--box-shadow-lg, 0 0.5rem 1rem rgba(0,0,0,0.15)); */ /* Shadow handled by parent panel */
-  z-index: 1; /* Local stacking context if needed, parent panel has higher z-index */
-  overflow-x: auto;
+  z-index: 1;
+  /* overflow-x: auto; */ /* Potentially remove or manage overflow carefully with resize handle */
   display: flex;
   flex-direction: column;
-  transition: opacity 0.3s ease-in-out; /* Keep transition for visibility */
+  transition: opacity 0.3s ease-in-out;
   opacity: 1;
+}
+
+.mood-board-resize-handle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 10px; /* Width of the draggable area */
+  height: 100%;
+  cursor: col-resize;
+  z-index: 10; /* Ensure it's above other content in the panel */
+  /* Visual cue for the handle */
+  border-left: 3px solid rgba(0, 0, 0, 0.2); /* Example: a subtle line */
+  /* background-color: rgba(0,0,0,0.05); */ /* Optional: slight background tint */
+}
+
+.mood-board-resize-handle:hover {
+  border-left: 3px solid rgba(0, 0, 0, 0.4); /* Darker line on hover */
+  /* background-color: rgba(0,0,0,0.1); */ /* Optional: darker tint on hover */
 }
 
 .mood-board-panel.hidden { /* For potential direct visibility control, though parent usually handles this */
@@ -32,9 +44,10 @@
 
 /* Added wrapper for better structure inside the panel */
 .mood-board-panel-content-wrapper {
+  height: 100%; /* Ensure it takes full height */
   display: flex;
   flex-direction: column;
-  height: 100%;
+  /* overflow: hidden; */ /* If resize handle is outside, content might need to hide overflow */
 }
 
 .mood-board-header { /* Renamed from .thematic-image-header */
@@ -106,7 +119,7 @@
   padding: 1rem;
   overflow-y: auto;
   flex-grow: 1; /* Allows this area to take available space and scroll */
-  text-align: center;
+  text-align: left;
 }
 
 .mood-board-loader, .mood-board-empty { /* Combined loader and empty message styling */
@@ -133,6 +146,7 @@
   flex-wrap: wrap;
   gap: 1rem; /* Spacing between images */
   justify-content: flex-start; /* Align items to the start */
+  max-width: 100%;
 }
 
 .mood-board-item-link {

--- a/campaign_crafter_ui/src/pages/CampaignEditorPage.css
+++ b/campaign_crafter_ui/src/pages/CampaignEditorPage.css
@@ -306,7 +306,7 @@
   position: fixed;
   right: 0;
   top: 0;
-  width: 400px; /* Increased width */
+  /* width: 400px; */ /* Removed: Now controlled by inline style */
   height: 100vh; /* Full viewport height */
   background-color: #fff; /* Or a suitable panel background */
   border-left: 1px solid #ccc;

--- a/campaign_crafter_ui/src/pages/CampaignEditorPage.tsx
+++ b/campaign_crafter_ui/src/pages/CampaignEditorPage.tsx
@@ -126,6 +126,7 @@ const CampaignEditorPage: React.FC = () => {
 
   // State for generating image for mood board
   const [isGeneratingForMoodBoard, setIsGeneratingForMoodBoard] = useState<boolean>(false);
+  const [moodBoardPanelWidth, setMoodBoardPanelWidth] = useState<number>(400); // Default width
 
   const handleSetThematicImage = async (imageUrl: string, prompt: string) => {
     // This function now only handles setting the *main* thematic image for the campaign.
@@ -199,6 +200,16 @@ const CampaignEditorPage: React.FC = () => {
       // thematicImageData state was removed, so no cleanup needed for it here
     }
   };
+
+  const handleMoodBoardResize = useCallback((newWidth: number) => {
+    // Add constraints for min/max width if desired
+    const minWidth = 250; // Example min width
+    const maxWidth = 800; // Example max width
+    let constrainedWidth = newWidth;
+    if (newWidth < minWidth) constrainedWidth = minWidth;
+    if (newWidth > maxWidth) constrainedWidth = maxWidth;
+    setMoodBoardPanelWidth(constrainedWidth);
+  }, []);
 
   const selectedLLMObject = useMemo(() => {
     if (availableLLMs.length > 0 && selectedLLMId) {
@@ -1301,7 +1312,10 @@ const CampaignEditorPage: React.FC = () => {
       )}
       <Tabs tabs={tabItems} />
       {isMoodBoardPanelOpen && (
-        <div className="mood-board-side-panel"> {/* Updated class name for consistency */}
+        <div
+          className="mood-board-side-panel"
+          style={{ width: `${moodBoardPanelWidth}px` }} // Apply dynamic width
+        >
           {/* Close button is now part of MoodBoardPanel's internal structure if desired, or keep here */}
           {/* For simplicity, MoodBoardPanel's onClose is used */}
           <MoodBoardPanel
@@ -1314,6 +1328,9 @@ const CampaignEditorPage: React.FC = () => {
             onUpdateMoodBoardUrls={setEditableMoodBoardUrls} // Pass the state setter
             campaignId={campaignId!} // Pass campaignId to MoodBoardPanel
             onRequestOpenGenerateImageModal={() => setIsGeneratingForMoodBoard(true)} // New callback
+            // Add these lines:
+            currentPanelWidth={moodBoardPanelWidth}
+            onResize={handleMoodBoardResize}
           />
         </div>
       )}


### PR DESCRIPTION
This commit introduces several improvements and bug fixes to the mood board feature.

Completed changes:

1.  **Fixed Delete Button Functionality:**
    - I modified the delete button within each mood board item in `MoodBoardPanel.tsx`.
    - I added an `onPointerDown` event handler that calls `e.stopPropagation()` to prevent the click event from propagating to the parent `<a>` tag and `dnd-kit` listeners. This resolves an issue where clicking delete would sometimes navigate to the image URL instead of deleting the item.

2.  **Fixed Rearranging Click Issue:**
    - I addressed an issue where finishing a drag-and-drop rearrangement of items in `MoodBoardPanel.tsx` could trigger an unintended click action on the moved item.
    - I implemented a solution using an `isDragEndEventProcessing` state flag within `MoodBoardPanel`. This flag is set to true briefly after a drag operation concludes.
    - An `onClickCapture` handler was added to the `<a>` tag within `SortableMoodBoardItem`. If `isDragEndEventProcessing` is true, this handler prevents the default click action and stops event propagation.

3.  **Improved Mood Board Wrapping and Width (CSS):**
    - In `MoodBoardPanel.css`: - I changed `text-align: center` to `text-align: left` for `.mood-board-content-area` for better content alignment. - I added `max-width: 100%` to `.mood-board-list` to ensure it doesn't overflow its container unnecessarily, improving wrapping robustness.

4.  **Added Draggable Resize Handle for Mood Board Panel:**
    - I modified `CampaignEditorPage.tsx`: - I added `moodBoardPanelWidth` state to manage the panel's width (defaulting to 400px, with min/max constraints of 250px/800px). - I implemented `handleMoodBoardResize` callback to update this width. - I applied the dynamic width to the `.mood-board-side-panel` div via inline styles. - I passed `currentPanelWidth` and `handleMoodBoardResize` as props to `MoodBoardPanel`.
    - I modified `MoodBoardPanel.tsx`:
        - I updated props to accept `currentPanelWidth` and `onResize`.
        - I added a `div.mood-board-resize-handle` element. - I implemented `mousedown` event logic on the handle to track mouse movements (`mousemove` on document) and call `onResize` with the calculated new width. `mouseup` listeners clean up these document event listeners.
    - I modified `MoodBoardPanel.css`: - I added styles for `.mood-board-resize-handle` (position, size, cursor, visual cues). - I ensured `.mood-board-panel` (the root of `MoodBoardPanel.tsx`) is set to `position: relative`, `width: 100%`, and `height: 100%` to correctly position the handle and fill its container.
    - I modified `CampaignEditorPage.css`:
        - I commented out the fixed `width: 400px;` for `.mood-board-side-panel` as it's now dynamically controlled.

5.  **Added Tests for Resize Functionality:**
    - I updated `MoodBoardPanel.test.tsx` with a new test suite for "Resize Handle Functionality".
    - These tests verify:
        - Correct rendering of the resize handle based on prop presence.
        - `onResize` callback is invoked with correctly calculated widths during simulated drag operations (mousedown, mousemove). - Event listeners are implicitly cleaned up (verified by `onResize` not being called after mouseup).