### PR TITLE
Fix: ESLint warnings for unused imports and missing useEffect dependency

### DIFF
--- a/campaign_crafter_ui/src/components/campaign_editor/CampaignDetailsEditor.tsx
+++ b/campaign_crafter_ui/src/components/campaign_editor/CampaignDetailsEditor.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'; // Import useState
 import { TextField, Grid, Typography, Card, CardContent, Box, IconButton } from '@mui/material'; // Added IconButton
 import Button from '../common/Button'; // Import common Button
-import CollapsibleSection from '../common/CollapsibleSection'; // Import CollapsibleSection
 import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined'; // Import icon
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'; // Import ExpandMoreIcon
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'; // Import ChevronRightIcon

--- a/campaign_crafter_ui/src/components/campaign_editor/CampaignSectionEditor.tsx
+++ b/campaign_crafter_ui/src/components/campaign_editor/CampaignSectionEditor.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Button,
   // Grid, // Removed Grid
   Typography,
   Card,
@@ -13,7 +12,6 @@ import {
   Paper,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator'; 
 import { CampaignSection, CampaignSectionUpdatePayload } from '../../services/campaignService'; // Corrected import
 import CampaignSectionView from '../CampaignSectionView';

--- a/campaign_crafter_ui/src/components/common/Tabs.tsx
+++ b/campaign_crafter_ui/src/components/common/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 import './Tabs.css'; // Import the CSS file
 
 export interface TabItem {


### PR DESCRIPTION
- Removed unused import `CollapsibleSection` from `CampaignDetailsEditor.tsx`.
- Removed unused imports `Button` and `AddCircleOutlineIcon` from `CampaignSectionEditor.tsx`.
- Removed unused import `useState` from `Tabs.tsx`.
- Verified that the `temperature` dependency was already present in the `useEffect` hook in `CampaignEditorPage.tsx`.