### PR TITLE
Fix: Use JSONB containment for compatible_types query

### DIFF
--- a/campaign_crafter_api/app/crud.py
+++ b/campaign_crafter_api/app/crud.py
@@ -1,5 +1,6 @@
 from typing import Optional, List, Dict # Added List and Dict
 from sqlalchemy.orm import Session
+from sqlalchemy.dialects.postgresql import JSONB # Added for JSONB casting
 from fastapi import HTTPException # Added HTTPException
 from passlib.context import CryptContext
 
@@ -142,9 +143,11 @@ def get_master_feature_for_type(db: Session, section_type: str) -> Optional[orm_
     Tries to find a specific match first, then a generic 'FullSection' feature if no specific match.
     """
     # Attempt to find a feature specifically compatible with the section_type and categorized as FullSection
+    # Construct a JSON array string for the check, e.g., '["typeA"]'
+    json_array_to_check = f'["{section_type}"]'
     db_feature = db.query(orm_models.Feature).filter(
         orm_models.Feature.feature_category == "FullSection",
-        orm_models.Feature.compatible_types.contains(f'"{section_type}"') # Assuming compatible_types is stored as JSON array string
+        orm_models.Feature.compatible_types.cast(JSONB).contains(json_array_to_check)
     ).first()
 
     if db_feature:


### PR DESCRIPTION
Replaced SQLAlchemy's default .contains() on a JSON column with a cast to JSONB and .contains() to ensure PostgreSQL's '@>' operator is used for checking if an element exists in the JSON array.

This resolves an 'operator does not exist: json ~~ text' error when querying the Feature model's compatible_types field against a PostgreSQL database.