### PR TITLE
Fix: Prevent text editor focus loss during debounced saves

### DIFF
--- a/CampaignCreatorApp/CampaignCreatorApp/CampaignDetailView.swift
+++ b/CampaignCreatorApp/CampaignCreatorApp/CampaignDetailView.swift
@@ -1718,9 +1718,19 @@ struct CampaignDetailView: View {
             print("[LLM_DEBUG CampaignDetailView] saveCampaignDetails: trulyRefreshedCampaign LLM Settings: ID=\(trulyRefreshedCampaign.selectedLLMId ?? "nil"), Temp=\(trulyRefreshedCampaign.temperature?.description ?? "nil")")
             print("[LLM_DEBUG CampaignDetailView] saveCampaignDetails: self.campaign (after update) LLM Settings: ID=\(self.campaign.selectedLLMId ?? "nil"), Temp=\(self.campaign.temperature?.description ?? "nil")")
 
-            self.viewRefreshTrigger = UUID() // Force UI refresh
+            // Only trigger full refresh for specific cases, not for every text field save
+            // to prevent losing focus on text editors.
+            if source != .titleField &&
+               source != .customSectionChange &&
+               source != .standardSectionChange &&
+               source != .conceptEditorDoneButton { // Concept editor also involves text input
+                self.viewRefreshTrigger = UUID()
+                print("Campaign details saved via \(source). Full view refresh triggered.")
+            } else {
+                print("Campaign details saved via \(source). Relied on @State update for UI refresh.")
+            }
             
-            print("Campaign details saved successfully via \(source). UI refreshed with direct API response.")
+            // print("Campaign details saved successfully via \(source). UI refreshed with direct API response.") // Message adjusted by conditional log
         } catch let error as APIError {
             errorMessage = "Save failed: \(error.localizedDescription)"
             showErrorAlert = true


### PR DESCRIPTION
I modified `saveCampaignDetails` in `CampaignDetailView.swift` to make the `viewRefreshTrigger` update conditional.

The full view refresh (triggered by changing `.id(viewRefreshTrigger)`) is no longer initiated if the save operation originated from a debounced text edit in fields such as campaign title, concept, or section titles/content.

For these text-editing saves, the view now relies on SwiftUI's standard state update mechanism (i.e., re-assigning `self.campaign` and other relevant `@State` variables with server response) to refresh UI parts. This prevents the active text editor from losing focus or resetting its state, which was causing a disruptive experience for you where the edit box would "go away" during typing.