### PR TITLE
Fix: Resolve CampaignLLMSettingsView compilation errors

### DIFF
--- a/CampaignCreatorApp/CampaignCreatorApp/CampaignLLMSettingsView.swift
+++ b/CampaignCreatorApp/CampaignCreatorApp/CampaignLLMSettingsView.swift
@@ -12,7 +12,7 @@ struct CampaignLLMSettingsView: View {
 
     // Using the specific nested type from CampaignDetailView.
     // This could be improved by moving AvailableLLM to a shared scope.
-    let availableLLMs: [CampaignDetailView.AvailableLLM]
+    let availableLLMs: [AvailableLLM] // Corrected: Use the global AvailableLLM type
 
     let currentFont: Font
     let currentTextColor: Color

--- a/CampaignCreatorApp/CampaignCreatorApp/LLMModels.swift
+++ b/CampaignCreatorApp/CampaignCreatorApp/LLMModels.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public struct AvailableLLM: Identifiable, Codable, Hashable {
+    public var id: String
+    public var name: String
+
+    public init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+public let placeholderLLMs: [AvailableLLM] = [
+    AvailableLLM(id: "gpt-4", name: "GPT-4"),
+    AvailableLLM(id: "gpt-3.5-turbo", name: "GPT-3.5 Turbo"),
+    AvailableLLM(id: "claude-3-opus", name: "Claude 3 Opus"),
+    AvailableLLM(id: "gemini-pro", name: "Gemini Pro")
+]


### PR DESCRIPTION
I've defined the `AvailableLLM` struct and `placeholderLLMs` constant globally within the app target. I also updated `CampaignLLMSettingsView` to use the correct global `AvailableLLM` type, resolving issues with type resolution and generic parameter inference in the Picker view.