### PR TITLE
Refactor: Centralize token management in a new TokenManager class

### DIFF
--- a/CampaignCreatorSwift/Sources/CampaignCreatorLib/TokenManager.swift
+++ b/CampaignCreatorSwift/Sources/CampaignCreatorLib/TokenManager.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public protocol TokenManaging: Sendable {
+    func getAccessToken() -> String?
+    func setAccessToken(_ token: String?)
+    func getRefreshToken(for username: String) -> String?
+    func setRefreshToken(_ token: String?, for username: String)
+    func clearTokens(for username: String)
+    func hasToken() -> Bool
+}
+
+public final class TokenManager: TokenManaging {
+    private let accessTokenKey = "AuthAccessToken"
+
+    public func getAccessToken() -> String? {
+        return UserDefaults.standard.string(forKey: accessTokenKey)
+    }
+
+    public func setAccessToken(_ token: String?) {
+        if let token = token {
+            UserDefaults.standard.set(token, forKey: accessTokenKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: accessTokenKey)
+        }
+    }
+
+    public func getRefreshToken(for username: String) -> String? {
+        return try? KeychainHelper.loadPassword(username: username)
+    }
+
+    public func setRefreshToken(_ token: String?, for username: String) {
+        if let token = token {
+            try? KeychainHelper.savePassword(username: username, password: token)
+        } else {
+            try? KeychainHelper.delete(username: username)
+        }
+    }
+
+    public func clearTokens(for username: String) {
+        UserDefaults.standard.removeObject(forKey: accessTokenKey)
+        try? KeychainHelper.delete(username: username)
+    }
+
+    public func hasToken() -> Bool {
+        return getAccessToken() != nil
+    }
+
+    public init() {}
+}


### PR DESCRIPTION
This commit refactors the token management logic into a new `TokenManager` class. This new class is responsible for storing and retrieving both the access token and the refresh token, with the refresh token now being stored in the keychain and associated with the username.

The `APIService` and `ContentViewModel` have been updated to use the new `TokenManager`, which centralizes the token management logic and makes the code more secure and easier to maintain.